### PR TITLE
feat: Task-7 Add authorization header to `/import` request

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
+import { Alert } from "@mui/material";
 
 type CSVFileImportProps = {
   url: string;
@@ -10,8 +11,11 @@ type CSVFileImportProps = {
 
 export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   const [file, setFile] = React.useState<File>();
+  const [uploadError, setUploadError] = React.useState<Number>(0);
+  const token = localStorage.getItem('authorization_token');
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUploadError(0);
     const files = e.target.files;
     if (files && files.length > 0) {
       const file = files[0];
@@ -24,25 +28,43 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   };
 
   const uploadFile = async () => {
-    // Get the presigned URL
-    const response = await axios({
-      method: "GET",
-      url,
-      params: {
-        fileName: encodeURIComponent(file?.name!),
-      },
-    });
-    const result = await fetch(response.data.url, {
-      method: "PUT",
-      body: file,
-    });
-    setFile(undefined);
+    try {
+      // Get the presigned URL
+      setUploadError(0);
+      const headers = token ? { headers: {'Authorization': `Basic ${token}` }} : {};
+      const response = await axios({
+        method: "GET",
+        url,
+        ...headers,
+        params: {
+          fileName: encodeURIComponent(file?.name!),
+        },
+      });
+      const result = await fetch(response.data.url, {
+        method: "PUT",
+        body: file,
+      });
+      setFile(undefined);
+    } catch(err) {
+      setFile(undefined);
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        if (status === 401 || status === 403) {
+          setUploadError(status);
+        }
+      }
+    }
   };
   return (
     <Box>
       <Typography variant="h6" gutterBottom>
         {title}
       </Typography>
+      {!!uploadError && (
+        <Box mb={2}>
+          <Alert severity="error">{`There was an error when uploading file. Status Code: ${uploadError.toString()}`}</Alert>
+        </Box>
+        )}
       {!file ? (
         <input type="file" onChange={onFileChange} />
       ) : (

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -4,7 +4,7 @@ const API_PATHS = {
   import: "https://k96x73rxtc.execute-api.us-west-1.amazonaws.com/prod",
   bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   cart: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  bffV2: "https://ew7p4ug5wl.execute-api.us-west-1.amazonaws.com/prod",
+  bffV2: "https://txshcl3ja3.execute-api.us-west-1.amazonaws.com/prod",
 };
 
 export default API_PATHS;


### PR DESCRIPTION
# Changes
- Added logic to add authorization header when importing CSV files
- Added alert for displaying error response with `401` and `403` status codes.
- Updated URL for bff.

# Link to Deployment
- Import Product page to upload CSV file: https://d2h8spcnjjuho2.cloudfront.net
- Click on Profile Icon > Manage Products

<img width="818" alt="image" src="https://github.com/user-attachments/assets/7c9c03d2-de42-4b85-a009-55cb4f4af1eb" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/6e2ea4bf-0ecf-48cb-9eab-b470bf17aaf1" />
